### PR TITLE
fix: use the ngFor trackBy directive to prevent focus loss on input

### DIFF
--- a/src/app/editor/properties/editor.component.html
+++ b/src/app/editor/properties/editor.component.html
@@ -6,10 +6,10 @@
         </div>
     </div>
     <div *ngIf="cell" class="container-fluid">
-      <div *ngFor="let value of cell.draggables[0].values; let i = index">
-          <div *ngFor="let v of cell.draggables[0].values[i].values; let j = index" class="row">
-            <div class='col-6'>{{ value.key}} {{j}}</div>
-            <div class='col-6'><input type='text' name="{{ v }}" [(ngModel)]='value.values[j]'/></div>
+      <div *ngFor="let value of cell.draggables[0].values">
+        <div *ngFor="let values of value.values; trackBy:trackByFn; let index = index" class="row">
+            <div class='col-6'>{{ value.key}} {{index}}</div>
+            <div class='col-6'><input type='text' [name]="values" [(ngModel)]="value.values[index]"/></div>
           </div>
       </div>
   </div>

--- a/src/app/editor/properties/editor.component.ts
+++ b/src/app/editor/properties/editor.component.ts
@@ -20,6 +20,9 @@ export class EditorComponent implements OnDestroy {
     this.subscription = this.propertiesService.getCell().subscribe(cell => {this.cell = cell; console.log('-- ' + this.cell); });
   }
 
+  trackByFn(index: number): number {
+    return index;
+  }
 
   ngOnDestroy(): void {
     // unsubscribe to ensure no memory leaks


### PR DESCRIPTION
https://stackoverflow.com/a/42329031


> You are repeating over an array and you are changing the items of the array (note that your items 
> are strings, which are primitives in JS and thus compared "by value"). Since new items are detected, old 
> elements are removed from the DOM and new ones are created (which obviously don't get focus).